### PR TITLE
Add Quill-style HTML editor server example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +301,12 @@ checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clipboard-win"
@@ -1120,6 +1132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1633,7 @@ dependencies = [
  "notify",
  "pulldown-cmark 0.9.6",
  "serde",
+ "tiny_http",
 ]
 
 [[package]]
@@ -2606,6 +2625,18 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,12 @@ egui-file-dialog = "0.10"
 pulldown-cmark = "0.9"
 notify = "6"
 egui_commonmark = "0.20"
+tiny_http = "0.12"
 
 [[bin]]
 name = "md_watch"
 path = "src/bin/md_watch.rs"
+
+[[bin]]
+name = "editor_server"
+path = "src/bin/editor_server.rs"

--- a/assets/editor.html
+++ b/assets/editor.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Éditeur Markdown in‑place (Bear / Obsidian‑like)</title>
+
+  <!-- =============================
+       Quill + Plugin Markdown
+       ============================= -->
+  <link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet" />
+  <style>
+    html,
+    body {
+      height: 100%;
+      margin: 0;
+      background: #fafafa;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+        Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    }
+
+    /* conteneur principal */
+    #editor {
+      height: 100%;
+    }
+
+    /* Harmonisation typographique façon Bear / Obsidian */
+    .ql-editor {
+      font-size: 1rem;
+      line-height: 1.6;
+    }
+    .ql-editor h1 {
+      font-size: 2.3rem;
+      margin: 1.2em 0 0.4em;
+    }
+    .ql-editor h2 {
+      font-size: 1.85rem;
+      margin: 1.2em 0 0.4em;
+    }
+    .ql-editor pre {
+      background: #2e3440;
+      color: #eceff4;
+      border-radius: 6px;
+      padding: 1rem;
+    }
+    .ql-editor blockquote {
+      border-left: 4px solid #dadada;
+      padding-left: 1rem;
+      color: #555;
+    }
+  </style>
+</head>
+<body>
+  <!-- Zone unique d’édition/rendu -->
+  <div id="editor"></div>
+
+  <!-- Quill core -->
+  <script src="https://cdn.quilljs.com/1.3.7/quill.js"></script>
+  <!-- Plugin quilljs-markdown (conversion Markdown live) -->
+  <script src="https://cdn.jsdelivr.net/npm/quilljs-markdown@latest/dist/quilljs-markdown.min.js"></script>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      // 1. Initialisation de Quill
+      const quill = new Quill('#editor', {
+        theme: 'snow',
+        placeholder: 'Tapez votre Markdown ici…',
+        modules: {
+          toolbar: [
+            [{ header: [1, 2, 3, false] }],
+            ['bold', 'italic', 'strike', 'code'],
+            ['blockquote', 'code-block'],
+            [{ list: 'ordered' }, { list: 'bullet' }],
+            ['link', 'image'],
+            ['clean']
+          ]
+        }
+      });
+
+      /*
+       * 2. Activation du plugin Markdown.
+       *    Quilljs‑markdown convertit immédiatement les séquences Markdown :
+       *    - "# " → <h1>
+       *    - "## " → <h2>
+       *    - "**gras**" après la 2ᵉ * devient <strong>
+       *    - "```lang" ouvre un bloc de code, etc.
+       */
+      // eslint-disable-next-line no-undef
+      new QuillMarkdown(quill, { syntax: true });
+    });
+  </script>
+</body>
+</html>

--- a/src/bin/editor_server.rs
+++ b/src/bin/editor_server.rs
@@ -1,0 +1,17 @@
+use tiny_http::{Header, Method, Response, Server};
+
+fn main() {
+    let server = Server::http("127.0.0.1:8000").expect("failed to bind server");
+    println!("Server running at http://127.0.0.1:8000/");
+    for request in server.incoming_requests() {
+        if request.method() == &Method::Get && request.url() == "/" {
+            let html = include_str!("../../assets/editor.html");
+            let response = Response::from_string(html).with_header(
+                Header::from_bytes("Content-Type", "text/html; charset=utf-8").unwrap(),
+            );
+            let _ = request.respond(response);
+        } else {
+            let _ = request.respond(Response::empty(404));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- serve `assets/editor.html` via new `editor_server` binary
- embed the HTML snippet with Quill and Markdown plugin
- add `tiny_http` dependency

## Testing
- `cargo check --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684a7371ca9c832ea8cf1ccd4aeae212